### PR TITLE
Update Patches.cs

### DIFF
--- a/LootMagnet/LootMagnet/Patches/Patches.cs
+++ b/LootMagnet/LootMagnet/Patches/Patches.cs
@@ -245,10 +245,12 @@ namespace LootMagnet {
                     ModState.SimGameState.AddFunds(sellCost, "LootMagnet", false, true);
                     ModState.SGCurrencyDisplay.UpdateMoney();
 
-                    // Create the new floatie text for the sell amount
+                    // Create the new floatie text for the sell amount, and position above item to prevent grabbing cursor focus
                     var floatie = new GameObject(ModConsts.LootMagnetFloatieGOName);
                     floatie.transform.SetParent(ModState.HBSPopupRoot.transform);
-                    floatie.transform.position = __instance.gameObject.transform.position;
+                    Vector3 vAbove = __instance.gameObject.transform.position;
+                    vAbove.y += ((RectTransform)__instance.gameObject.transform).rect.height / 2;
+                    floatie.transform.position = vAbove;
 
                     var text = floatie.AddComponent<TextMeshProUGUI>();
                     text.font = ModState.FloatieFont;


### PR DESCRIPTION
Float text for salvage item sale price would float on top of the next item to sell, which slows down selling those items. This changes it so that it float above the item that was shift-clicked.